### PR TITLE
Fix for error with gcc8

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,4 +1,6 @@
 c_compiler_version:
-  - 7.3.0
+  - 7.3.0          # [x86_64]               
+  - 8.2.0          # [ppc64le]
 cxx_compiler_version:
-  - 7.3.0
+  - 7.3.0          # [x86_64]
+  - 8.2.0          # [ppc64le]

--- a/recipe/0102-Fix-error-using-gcc-8.patch
+++ b/recipe/0102-Fix-error-using-gcc-8.patch
@@ -1,0 +1,44 @@
+From f876e817fa98ab7f14bf498c3a96e3a7a29ec823 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Thu, 29 Jul 2021 09:40:52 -0400
+Subject: [PATCH] Fix error using gcc 8
+
+---
+ dali/operators/audio/mfcc/mfcc.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/dali/operators/audio/mfcc/mfcc.h b/dali/operators/audio/mfcc/mfcc.h
+index c6d4d06e..eb55f03c 100644
+--- a/dali/operators/audio/mfcc/mfcc.h
++++ b/dali/operators/audio/mfcc/mfcc.h
+@@ -88,22 +88,22 @@ class MFCC : public Operator<Backend> {
+   void GetArguments(const workspace_t<Backend> &ws) {
+     auto nsamples = ws.template InputRef<Backend>(0).shape().size();
+     DctArgs arg;
+-    arg.ndct = spec_.template GetArgument<int>("n_mfcc");
++    arg.ndct = this->spec_.template GetArgument<int>("n_mfcc");
+     DALI_ENFORCE(arg.ndct > 0, "number of MFCCs should be > 0");
+ 
+-    arg.dct_type = spec_.template GetArgument<int>("dct_type");
++    arg.dct_type = this->spec_.template GetArgument<int>("dct_type");
+     DALI_ENFORCE(arg.dct_type >= 1 && arg.dct_type <= 4,
+       make_string("Unsupported DCT type: ", arg.dct_type, ". Supported types are: 1, 2, 3, 4."));
+ 
+-    arg.normalize = spec_.template GetArgument<bool>("normalize");
++    arg.normalize = this->spec_.template GetArgument<bool>("normalize");
+     if (arg.normalize) {
+       DALI_ENFORCE(arg.dct_type != 1, "Ortho-normalization is not supported for DCT type I.");
+     }
+ 
+-    axis_ = spec_.template GetArgument<int>("axis");
++    axis_ = this->spec_.template GetArgument<int>("axis");
+     DALI_ENFORCE(axis_ >= 0);
+ 
+-    lifter_ = spec_.template GetArgument<float>("lifter");
++    lifter_ = this->spec_.template GetArgument<float>("lifter");
+     args_.clear();
+     args_.resize(nsamples, arg);
+   }
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   patches:
     - 0002-cxx11-abi.patch
     - 0101-Fixed-cmake-error.patch        #[x86_64]
+    - 0102-Fix-error-using-gcc-8.patch    #[ppc64le]
 
 build:
   number: 2


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes part of the build error with gcc 8. There is one more error which is trickier and as per gcc's documentation, it is fixed in gcc 9.1
```
/mnt/pai/home/npanpa23/anaconda3/conda-bld/dali_1627563466949/work/dali/operators/image/remap/warp.h:319:20: internal compiler error: in tsubst_copy, at cp/pt.c:15478
               auto param_provider = This().template CreateParamProvider<spatial_ndim, BorderType>();
                    ^~~~~~~~~~~~~~
/mnt/pai/home/npanpa23/anaconda3/conda-bld/dali_1627563466949/work/third_party/boost/preprocessor/include/boost/preprocessor/facilities/identity.hpp:23:34: note: in definition of macro 'BOOST_PP_IDENTITY'
 # define BOOST_PP_IDENTITY(item) item BOOST_PP_EMPTY
                                  ^~~~
/mnt/pai/home/npanpa23/anaconda3/conda-bld/dali_1627563466949/work/third_party/boost/preprocessor/include/boost/preprocessor/tuple/rem.hpp:123:49: note: in expansion of macro 'BOOST_PP_REM'
 #     define BOOST_PP_TUPLE_REM_CTOR_O_1(tuple) BOOST_PP_REM tuple
                                                 ^~~~~~~~~~~~
/mnt/pai/home/npanpa23/anaconda3/conda-bld/dali_1627563466949/work/third_party/boost/preprocessor/include/boost/preprocessor/cat.hpp:29:34: note: in expansion of macro 'BOOST_PP_TUPLE_REM_CTOR_O_1'
 #    define BOOST_PP_CAT_I(a, b) a ## b
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
