### PR TITLE
fix 1.2 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0101-Fixed-cmake-error.patch        #[x86_64]
 
 build:
-  number: 9
+  number: 10
   string: h{{ PKG_HASH }}_cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   script_env:
     - CUDA_HOME
@@ -38,6 +38,7 @@ requirements:
     - libsndfile
   host:
     - opencv {{ opencv }}
+    - jpeg {{ jpeg }}
     - libboost {{ boost }}
     - tensorflow {{ tensorflow }}
     - python {{ python }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Explicitly pin `jpeg` version (`9b`) used otherwise newer version (`9d`)  is pulled by `opencv `install and leads to the following error during DALI build for open-ce-v1.2.4. 

```
[ 68%] Building CXX object dali/operators/CMakeFiles/dali_operators.dir/math/expressions/expression_factory_instances/expression_factory_mul.cc.o
/opt/conda/conda-bld/dali_1632875327818/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/libjpeg.so.9: undefined reference to `memcpy@GLIBC_2.14' 
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
