### PR TITLE
Pinned zlib and openh264

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0101-Fixed-cmake-error.patch        #[x86_64]
 
 build:
-  number: 11
+  number: 12
   string: h{{ PKG_HASH }}_cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   script_env:
     - CUDA_HOME
@@ -34,6 +34,8 @@ requirements:
     - jpeg-turbo {{ jpegturbo }}
     - ffmpeg {{ ffmpeg }}
     - python {{ python }}
+    - zlib {{ zlib }} h7b6447c_3
+    - openh264 2.1.0
     - lmdb {{ lmdb }}
     - libsndfile
   host:
@@ -49,6 +51,8 @@ requirements:
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
     - libgfortran-ng  {{ libgfortran }}
+    - zlib {{ zlib }} h7b6447c_3
+    - openh264 2.1.0
   run:
     - python {{ python }}
     - tensorflow {{ tensorflow }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes build failure caused due to zlib update. zlib 1.2.11 package is updated on anaconda 6 days ago. opencv pins it to a particular build to avoid an error in the latest build of zlib 1.2.11. Hence, same is done in DALI too.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
