### PR TITLE
added call to find_package CUDA

### DIFF
--- a/recipe/0001-fix-build-by-adding-call-to-find_package-for-CUDA.patch
+++ b/recipe/0001-fix-build-by-adding-call-to-find_package-for-CUDA.patch
@@ -1,0 +1,25 @@
+From 87546bd96f52fe9a0c8ae022722dfc439e778bbd Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Wed, 21 Feb 2024 09:48:25 +0000
+Subject: [PATCH] fix build by adding call to find_package for CUDA
+
+---
+ cmake/Dependencies.common.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/cmake/Dependencies.common.cmake b/cmake/Dependencies.common.cmake
+index 0c2ba6e4..13ca3e1a 100644
+--- a/cmake/Dependencies.common.cmake
++++ b/cmake/Dependencies.common.cmake
+@@ -12,6 +12,8 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++find_package(CUDA)
++
+ ##################################################################
+ # OpenCV
+ ##################################################################
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   git_url: https://github.com/NVIDIA/DALI/
   git_rev: v{{ build_version }}
   patches:
+    - 0001-fix-build-by-adding-call-to-find_package-for-CUDA.patch
     - 0002-cxx11-abi.patch
     - 0303-Fixed-errors-encountered-with-GCC-11.patch
     - 0304-Fixed-Protobuf-detection-via-cmake.patch


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes the following error:
```
CMake Error at third_party/cvcuda/src/cvcuda/CMakeLists.txt:89 (add_library):
  Target "cvcuda" links to target "CUDA::cudart_static" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
